### PR TITLE
fix: remove unnecessary GitHub CLI action

### DIFF
--- a/.github/workflows/auto-pr-dev-to-main.yml
+++ b/.github/workflows/auto-pr-dev-to-main.yml
@@ -18,9 +18,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Fetch all history for proper comparison
-
-      - name: Setup GitHub CLI
-        uses: github/cli-action@v2
+          
+      # GitHub CLI is pre-installed on GitHub Actions runners
         
       - name: Check for existing PRs
         id: check-pr


### PR DESCRIPTION
- GitHub CLI is pre-installed on GitHub Actions runners
- Remove the GitHub CLI action that was causing errors

🤖 Generated with [Claude Code](https://claude.ai/code)