### PR TITLE
fix: add required permissions for GitHub CLI

### DIFF
--- a/.github/workflows/auto-pr-dev-to-main.yml
+++ b/.github/workflows/auto-pr-dev-to-main.yml
@@ -6,6 +6,11 @@ on:
       - dev
   workflow_dispatch:  # Allow manual triggering
 
+# These permissions are needed for the GitHub CLI to create pull requests
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   create-pr:
     name: Create PR from Dev to Main


### PR DESCRIPTION
- Add pull-requests write and contents read permissions
- These permissions are needed for the GitHub workflow to create PRs

🤖 Generated with [Claude Code](https://claude.ai/code)