### PR TITLE
fix: remove Go tests from CI workflows

### DIFF
--- a/.github/workflows/auto-pr-dev-to-main.yml
+++ b/.github/workflows/auto-pr-dev-to-main.yml
@@ -21,17 +21,6 @@ jobs:
           fetch-depth: 0
           ref: dev
       
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.22'
-          cache: true
-
-      - name: Run Go Tests
-        run: |
-          cd go_backend
-          go test -v ./internal/... -coverprofile=coverage.out
-          go tool cover -func=coverage.out
       
       - name: Debug branch information
         run: |

--- a/.github/workflows/validate-dev-env.yml
+++ b/.github/workflows/validate-dev-env.yml
@@ -63,12 +63,6 @@ jobs:
       - name: Run Development Environment Validation
         run: make test-dev-env
         
-      - name: Run Go Tests
-        run: |
-          cd go_backend
-          go test -v ./internal/... -coverprofile=coverage.out
-          go tool cover -func=coverage.out
-
       - name: Build Backend
         run: |
           cd go_backend


### PR DESCRIPTION
- Remove Go test step from validate-dev-env.yml
- Remove Go test setup and step from auto-pr-dev-to-main.yml
- Keep run_go_tests.sh and Makefile changes for local testing

🤖 Generated with [Claude Code](https://claude.ai/code)