### PR TITLE
fix: handle GoReleaser snapshot builds for non-tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,12 @@ jobs:
           echo "Build test successful!"
           rm -f /tmp/mix-test
 
-  # Cross-platform release build
+  # macOS release build
   release:
     needs: validate
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    # Run on tags, manual dispatch, or pushes to main/dev for testing
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'))
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -88,12 +89,23 @@ jobs:
       - name: Download Go modules
         run: cd mix_agent && go mod download
 
+      - name: Check if this is a tagged release
+        id: check_tag
+        run: |
+          if [[ ${{ github.ref_type }} == 'tag' ]]; then
+            echo "is_tag=true" >> $GITHUB_OUTPUT
+            echo "args=release --clean" >> $GITHUB_OUTPUT
+          else
+            echo "is_tag=false" >> $GITHUB_OUTPUT
+            echo "args=build --snapshot --clean" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: ${{ steps.check_tag.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Uncomment when ready for package manager publishing
@@ -109,6 +121,7 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/checksums.txt
+            dist/mix_darwin_*/*
           retention-days: 30
 
   # Test macOS builds (for PRs and non-tag pushes)


### PR DESCRIPTION
- Add conditional logic to detect tagged vs non-tagged releases
- Use 'goreleaser build --snapshot --clean' for feature branches
- Use 'goreleaser release --clean' for tagged releases
- Expand artifact upload to include all build outputs
- Allow release job to run on main/dev pushes for testing

This resolves the "git doesn't contain any tags" error while enabling proper snapshot builds for development and testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)