### PR TITLE
feat: add universal URL support to ReadMedia tool

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -42,8 +42,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
-github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
-github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -52,8 +50,6 @@ github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3 h1:boJj011Hh+874zpIySe
 github.com/cncf/xds/go v0.0.0-20241223141626-cff3c89139a3/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 h1:aQ3y1lwWyqYPiWZThqv1aFbZMiM9vblcSArJRf2Irls=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
-github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
-github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -101,6 +97,12 @@ github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
+github.com/hhrutter/lzw v1.0.0 h1:laL89Llp86W3rRs83LvKbwYRx6INE8gDn0XNb1oXtm0=
+github.com/hhrutter/lzw v1.0.0/go.mod h1:2HC6DJSn/n6iAZfgM3Pg+cP1KxeWc3ezG8bBqW5+WEo=
+github.com/hhrutter/pkcs7 v0.2.0 h1:i4HN2XMbGQpZRnKBLsUwO3dSckzgX142TNqY/KfXg+I=
+github.com/hhrutter/pkcs7 v0.2.0/go.mod h1:aEzKz0+ZAlz7YaEMY47jDHL14hVWD6iXt0AgqgAvWgE=
+github.com/hhrutter/tiff v1.0.2 h1:7H3FQQpKu/i5WaSChoD1nnJbGx4MxU5TlNqqpxw55z8=
+github.com/hhrutter/tiff v1.0.2/go.mod h1:pcOeuK5loFUE7Y/WnzGw20YxUdnqjY1P0Jlcieb/cCw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -119,6 +121,8 @@ github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYW
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mfridman/xflag v0.1.0 h1:TWZrZwG1QklFX5S4j1vxfF1sZbZeZSGofMwPMLAF29M=
 github.com/mfridman/xflag v0.1.0/go.mod h1:/483ywM5ZO5SuMVjrIGquYNE5CzLrj5Ux/LxWWnjRaE=
 github.com/microsoft/go-mssqldb v1.8.0 h1:7cyZ/AT7ycDsEoWPIXibd+aVKFtteUNhDGf3aobP+tw=
@@ -141,6 +145,8 @@ github.com/prometheus/procfs v0.16.0 h1:xh6oHhKwnOJKMYiYBDWmkHqQPyiY40sny36Cmx2b
 github.com/prometheus/procfs v0.16.0/go.mod h1:8veyXUu3nGP7oaCxhX6yeaM5u4stL2FeMXnCqhDthZg=
 github.com/psanford/httpreadat v0.1.0 h1:VleW1HS2zO7/4c7c7zNl33fO6oYACSagjJIyMIwZLUE=
 github.com/psanford/httpreadat v0.1.0/go.mod h1:Zg7P+TlBm3bYbyHTKv/EdtSJZn3qwbPwpfZ/I9GKCRE=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
@@ -150,10 +156,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8WS0hE=
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/tursodatabase/libsql-client-go v0.0.0-20240902231107-85af5b9d094d h1:dOMI4+zEbDI37KGb0TI44GUAwxHF9cMsIoDTJ7UmgfU=
-github.com/tursodatabase/libsql-client-go v0.0.0-20240902231107-85af5b9d094d/go.mod h1:l8xTsYB90uaVdMHXMCxKKLSgw5wLYBwBKKefNIUnm9s=
 github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
 github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vertica/vertica-sql-go v1.3.3 h1:fL+FKEAEy5ONmsvya2WH5T8bhkvY27y/Ik3ReR2T+Qw=
@@ -217,6 +219,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422/go.
 google.golang.org/genproto/googleapis/api v0.0.0-20250721164621-a45f3dfb1074 h1:mVXdvnmR3S3BQOqHECm9NGMjYiRtEvDYcqAqedTXY6s=
 google.golang.org/genproto/googleapis/api v0.0.0-20250721164621-a45f3dfb1074/go.mod h1:vYFwMYFbmA8vl6Z/krj/h7+U/AqpHknwJX4Uqgfyc7I=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=
 howett.net/plist v1.0.1/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 lukechampine.com/adiantum v1.1.1 h1:4fp6gTxWCqpEbLy40ExiYDDED3oUNWx5cTqBCtPdZqA=

--- a/mix_agent/go.mod
+++ b/mix_agent/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/coder/websocket v1.8.13 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/pdfcpu/pdfcpu v0.11.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 )

--- a/mix_agent/go.sum
+++ b/mix_agent/go.sum
@@ -112,6 +112,8 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/openai/openai-go v0.1.0-beta.2 h1:Ra5nCFkbEl9w+UJwAciC4kqnIBUCcJazhmMA0/YN894=
 github.com/openai/openai-go v0.1.0-beta.2/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/pdfcpu/pdfcpu v0.11.0 h1:mL18Y3hSHzSezmnrzA21TqlayBOXuAx7BUzzZyroLGM=
+github.com/pdfcpu/pdfcpu v0.11.0/go.mod h1:F1ca4GIVFdPtmgvIdvXAycAm88noyNxZwzr9CpTy+Mw=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/mix_agent/internal/config/prompts/tools/read_media.md
+++ b/mix_agent/internal/config/prompts/tools/read_media.md
@@ -1,12 +1,11 @@
-Analyzes multimedia files (images, audio, video) using AI to  generate descriptions, or create transcripts. Assume this tool is able to read all local media files on the machine,  but any URL is not supported. If the user provides a path to a file assume that path is valid. If the user provides a URL, first download the media file to the working directory before using the tool. It is okay to read a file that does not exist; an error will be returned.
+Analyzes multimedia files using AI to  generate descriptions, or create transcripts. Assume this tool is able to read all local media files on the machine,  but any URL is not supported. If the user provides a path to a file assume that path is valid. If the user provides a URL, first download the media file to the working directory before using the tool. It is okay to read a file that does not exist; an error will be returned.
 
 Usage notes:
 
-- Supports three analysis types: "image", "audio", or "video"
+- Supports three media types: "image", "audio", "video" or "pdf"
 - Can process single files or entire directories with optional recursive scanning
 - Requires either file_path OR directory_path parameter (mutually exclusive)
-- All file paths must be absolute paths for security. Relative paths and are not allowed
-- All URL's except youtube URL's are not allowed. ReadMedia can analyze youtube videos directly.
+- All file paths must be absolute paths or URL's for security. Relative paths are not allowed
 - For audio files: audio_mode parameter required ("transcript" or "description")
 - For video files: video_mode parameter required ("description")
-- For image files: no additional mode parameter needed
+- For image files and pdf's: no additional mode parameter needed

--- a/mix_agent/internal/config/prompts/tools/read_media.md
+++ b/mix_agent/internal/config/prompts/tools/read_media.md
@@ -6,6 +6,9 @@ Usage notes:
 - Can process single files or entire directories with optional recursive scanning
 - Requires either file_path OR directory_path parameter (mutually exclusive)
 - All file paths must be absolute paths or URL's for security. Relative paths are not allowed
+- This tool can analyze youtube videos directly.
 - For audio files: audio_mode parameter required ("transcript" or "description")
 - For video files: video_mode parameter required ("description")
 - For image files and pdf's: no additional mode parameter needed
+- For PDF files: PDFs are automatically truncated to the first 10 pages when no page range is specified via the pdf_pages parameter. To analyze more pages, specify a page range (e.g., pdf_pages: "1-20").
+- For video files: Videos are automatically truncated to the first 10 minutes when no time interval is specified via the video_interval parameter. To analyze longer videos, specify a time interval (e.g., video_interval: "00:00:00-00:20:00").

--- a/mix_agent/internal/config/prompts/tools/read_media.md
+++ b/mix_agent/internal/config/prompts/tools/read_media.md
@@ -1,14 +1,23 @@
-Analyzes multimedia files using AI to  generate descriptions, or create transcripts. Assume this tool is able to read all local media files on the machine,  but any URL is not supported. If the user provides a path to a file assume that path is valid. If the user provides a URL, first download the media file to the working directory before using the tool. It is okay to read a file that does not exist; an error will be returned.
+Analyzes multimedia files using AI. If the user provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned. Supports four media types: "image", "audio", "video" or "pdf"
 
 Usage notes:
 
-- Supports three media types: "image", "audio", "video" or "pdf"
-- Can process single files or entire directories with optional recursive scanning
-- Requires either file_path OR directory_path parameter (mutually exclusive)
 - All file paths must be absolute paths or URL's for security. Relative paths are not allowed
-- This tool can analyze youtube videos directly.
-- For audio files: audio_mode parameter required ("transcript" or "description")
-- For video files: video_mode parameter required ("description")
-- For image files and pdf's: no additional mode parameter needed
-- For PDF files: PDFs are automatically truncated to the first 10 pages when no page range is specified via the pdf_pages parameter. To analyze more pages, specify a page range (e.g., pdf_pages: "1-20").
-- For video files: Videos are automatically truncated to the first 10 minutes when no time interval is specified via the video_interval parameter. To analyze longer videos, specify a time interval (e.g., video_interval: "00:00:00-00:20:00").
+- To analyze image files:
+    1. For basic descriptions (e.g., "Caption this image" or "Describe what you see in this image")
+    2. For visual question answering (e.g., "What color is the car?" or "How many people are in this photo?")
+    3. For text extraction (e.g., "Extract and transcribe all text visible in this image")
+- To analyze audio files:
+    1. To get a transcript, request it in the prompt (e.g., "Generate a transcript of the speech").
+    2. Input prompts can reference specific audio segments using MM:SS timestamps (e.g., "Provide a transcript between 02:30 and 03:29").
+- To analyze video files:
+    1. For content extraction (e.g., "Summarize this video in 3-5 sentences" or "Extract key points and create a bulleted outline of topics covered")
+    2. Input prompts can reference specific video timestamps using MM:SS format (e.g., "What happens at 01:30?" or "Compare the scenes at 00:05 and 00:10").
+    3. For transcription (e.g., "Transcribe the audio from this video, giving timestamps for salient events. Also, provide visual descriptions.")
+    4. Videos are automatically truncated to the first 10 minutes when no time interval is specified via the video_interval parameter. To analyze longer videos, specify a time interval (e.g., video_interval: "00:00:00-00:20:00").
+    5. This tool can analyze youtube videos directly.
+- To analyze PDF files
+    1. For summarization and extraction (e.g., "Summarize the key findings from this research paper" or "Extract all methodology details")
+    2. For document question answering (e.g., "What conclusions are drawn in section 3?" or "List all figures and their captions")
+    3. For structured information extraction (e.g., "Extract all tables into JSON format" or "Create a bulleted outline of the main topics")
+    4. PDFs are automatically truncated to the first 10 pages when no page range is specified via the pdf_pages parameter. To analyze more pages, specify a page range (e.g., pdf_pages: "1-20").

--- a/mix_agent/internal/config/prompts/tools/show_media.md
+++ b/mix_agent/internal/config/prompts/tools/show_media.md
@@ -202,7 +202,8 @@ outputs (required): Array of media outputs to showcase
 - Include meaningful titles - Help users understand what they're viewing  
 - Add descriptions for context - Especially useful for complex or reference materials
 - Multiple outputs supported - Display multiple related media files at once
-- Useit it to show previews and references
+- Use this tool to show previews and references
 - Always use `type: "youtube"` for YouTube URLs (youtube.com, youtu.be). This enables proper YouTube iframe embedding with controls and full-screen support
+- Always convert Excel files (.xlsx, .xls) to CSV format before displaying with this tool
 
 This tool transforms file paths into beautiful media displays in the conversation interface.

--- a/mix_agent/internal/http/rest_files.go
+++ b/mix_agent/internal/http/rest_files.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"unicode"
 
 	"mix/internal/app"
@@ -48,9 +49,23 @@ func sanitizeFilename(filename string) string {
 			result = append(result, r)
 		}
 	}
-	
+
+	// Handle dots - replace all except the one before the file extension
+	withoutSpaces := string(result)
+	lastDotPos := strings.LastIndex(withoutSpaces, ".")
+
+	if lastDotPos > 0 { // > 0 to preserve hidden files starting with .
+		basename := withoutSpaces[:lastDotPos]
+		extension := withoutSpaces[lastDotPos:] // includes the dot
+
+		// Replace dots in basename with underscores
+		basename = strings.ReplaceAll(basename, ".", "_")
+
+		withoutSpaces = basename + extension
+	}
+
 	// Collapse multiple consecutive underscores into a single underscore
-	sanitized := regexp.MustCompile(`_+`).ReplaceAllString(string(result), "_")
+	sanitized := regexp.MustCompile(`_+`).ReplaceAllString(withoutSpaces, "_")
 	return sanitized
 }
 

--- a/mix_agent/internal/llm/provider/gemini.go
+++ b/mix_agent/internal/llm/provider/gemini.go
@@ -654,10 +654,11 @@ func (g *geminiClient) isSupportedInlineFormat(mimeType string) bool {
 	// Supported inline formats according to Gemini API docs
 	supportedInlineFormats := []string{
 		"image/png",
-		"image/jpeg", 
+		"image/jpeg",
 		"image/webp",
 		"image/heic",
 		"image/heif",
+		"application/pdf",
 	}
 	
 	for _, supported := range supportedInlineFormats {

--- a/mix_agent/internal/llm/provider/gemini.go
+++ b/mix_agent/internal/llm/provider/gemini.go
@@ -63,10 +63,30 @@ func (g *geminiClient) convertMessages(messages []message.Message) []*genai.Cont
 			for _, binaryContent := range msg.BinaryContent() {
 				// Handle images and videos via inline data for supported formats
 				if g.isSupportedInlineFormat(binaryContent.MIMEType) || g.isSupportedVideoFormat(binaryContent.MIMEType) {
-					parts = append(parts, &genai.Part{InlineData: &genai.Blob{
+					part := &genai.Part{InlineData: &genai.Blob{
 						MIMEType: binaryContent.MIMEType,
 						Data:     binaryContent.Data,
-					}})
+					}}
+
+					// Add video metadata if provided
+					if binaryContent.StartOffset != "" && binaryContent.EndOffset != "" {
+						startDuration, err := time.ParseDuration(binaryContent.StartOffset)
+						if err != nil {
+							logging.Warn("Failed to parse video start offset", "offset", binaryContent.StartOffset, "error", err)
+						} else {
+							endDuration, err := time.ParseDuration(binaryContent.EndOffset)
+							if err != nil {
+								logging.Warn("Failed to parse video end offset", "offset", binaryContent.EndOffset, "error", err)
+							} else {
+								part.VideoMetadata = &genai.VideoMetadata{
+									StartOffset: startDuration,
+									EndOffset:   endDuration,
+								}
+							}
+						}
+					}
+
+					parts = append(parts, part)
 				} else {
 					// For unsupported inline formats, log warning and skip
 					// Note: Video upload via File API would require additional implementation
@@ -76,7 +96,27 @@ func (g *geminiClient) convertMessages(messages []message.Message) []*genai.Cont
 			}
 			for _, uriContent := range msg.URIContent() {
 				// Handle URIs using Gemini's native URI support
-				parts = append(parts, genai.NewPartFromURI(uriContent.URI, uriContent.MIMEType))
+				part := genai.NewPartFromURI(uriContent.URI, uriContent.MIMEType)
+
+				// Add video metadata if provided
+				if uriContent.StartOffset != "" && uriContent.EndOffset != "" {
+					startDuration, err := time.ParseDuration(uriContent.StartOffset)
+					if err != nil {
+						logging.Warn("Failed to parse video start offset", "offset", uriContent.StartOffset, "error", err)
+					} else {
+						endDuration, err := time.ParseDuration(uriContent.EndOffset)
+						if err != nil {
+							logging.Warn("Failed to parse video end offset", "offset", uriContent.EndOffset, "error", err)
+						} else {
+							part.VideoMetadata = &genai.VideoMetadata{
+								StartOffset: startDuration,
+								EndOffset:   endDuration,
+							}
+						}
+					}
+				}
+
+				parts = append(parts, part)
 			}
 			history = append(history, &genai.Content{
 				Parts: parts,

--- a/mix_agent/internal/llm/tools/pdf_utils.go
+++ b/mix_agent/internal/llm/tools/pdf_utils.go
@@ -1,0 +1,187 @@
+package tools
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
+	"mix/internal/logging"
+)
+
+const (
+	// MaxPDFPagesWithoutTruncation is the maximum number of pages to process
+	// from a PDF when no explicit page range is specified
+	MaxPDFPagesWithoutTruncation = 10
+)
+
+// ParsePageSelection parses a page selection string into individual page numbers
+// Supports formats like: "5", "1-3", "1,3,5", "1-3,7,10-12"
+func ParsePageSelection(pages string) ([]int, error) {
+	if pages == "" {
+		return nil, nil
+	}
+
+	var pageNumbers []int
+	parts := strings.Split(pages, ",")
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		if strings.Contains(part, "-") {
+			// Handle range like "1-3"
+			rangeParts := strings.Split(part, "-")
+			if len(rangeParts) != 2 {
+				return nil, fmt.Errorf("invalid range format: %s", part)
+			}
+
+			start, err := strconv.Atoi(strings.TrimSpace(rangeParts[0]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid start page: %s", rangeParts[0])
+			}
+
+			end, err := strconv.Atoi(strings.TrimSpace(rangeParts[1]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid end page: %s", rangeParts[1])
+			}
+
+			if start > end {
+				return nil, fmt.Errorf("start page cannot be greater than end page: %d > %d", start, end)
+			}
+
+			for i := start; i <= end; i++ {
+				pageNumbers = append(pageNumbers, i)
+			}
+		} else {
+			// Handle single page like "5"
+			pageNum, err := strconv.Atoi(part)
+			if err != nil {
+				return nil, fmt.Errorf("invalid page number: %s", part)
+			}
+			pageNumbers = append(pageNumbers, pageNum)
+		}
+	}
+
+	if len(pageNumbers) == 0 {
+		return nil, fmt.Errorf("no valid page numbers found")
+	}
+
+	// Remove duplicates and sort
+	uniquePages := make(map[int]bool)
+	var result []int
+	for _, page := range pageNumbers {
+		if page <= 0 {
+			return nil, fmt.Errorf("page numbers must be positive: %d", page)
+		}
+		if !uniquePages[page] {
+			uniquePages[page] = true
+			result = append(result, page)
+		}
+	}
+
+	return result, nil
+}
+
+// ExtractPDFPages extracts specific pages from a PDF and returns the new PDF as bytes.
+// Returns: (pdfData, wasTruncated, error)
+// - If pages is empty and PDF has > 10 pages: automatically extracts first 10 pages and returns wasTruncated=true
+// - If pages is empty and PDF has <= 10 pages: returns original PDF with wasTruncated=false
+// - If pages is specified: extracts those pages with wasTruncated=false
+func ExtractPDFPages(pdfData []byte, pages string) ([]byte, bool, error) {
+	// Create a reader from the PDF bytes
+	reader := bytes.NewReader(pdfData)
+
+	// Read and validate the PDF context to properly populate page count
+	ctx, err := api.ReadAndValidate(reader, model.NewDefaultConfiguration())
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read and validate PDF: %w", err)
+	}
+
+	pageCount := ctx.PageCount
+	logging.Debug("PDF context loaded", "pageCount", pageCount, "requestedPages", pages)
+
+	// Determine which pages to extract
+	var pageNumbers []int
+	var wasTruncated bool
+
+	if pages == "" {
+		// No pages specified - check if auto-truncation is needed
+		if pageCount > MaxPDFPagesWithoutTruncation {
+			// Auto-truncate to first MaxPDFPagesWithoutTruncation pages
+			pageNumbers = make([]int, MaxPDFPagesWithoutTruncation)
+			for i := range MaxPDFPagesWithoutTruncation {
+				pageNumbers[i] = i + 1
+			}
+			wasTruncated = true
+		} else {
+			// PDF has MaxPDFPagesWithoutTruncation or fewer pages, return original
+			return pdfData, false, nil
+		}
+	} else {
+		// Pages explicitly specified - parse the selection
+		pageNumbers, err = ParsePageSelection(pages)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to parse page selection: %w", err)
+		}
+		wasTruncated = false
+	}
+
+	// Validate that requested pages exist
+	for _, pageNum := range pageNumbers {
+		if pageNum > pageCount {
+			return nil, false, fmt.Errorf("page %d does not exist (PDF has %d pages)", pageNum, pageCount)
+		}
+	}
+
+	// Extract each requested page individually
+	logging.Debug("Extracting PDF pages", "pages", pageNumbers, "wasTruncated", wasTruncated)
+	var pageReaders []io.ReadSeeker
+	for _, pageNum := range pageNumbers {
+		// Extract the page as an io.Reader
+		pageReader, err := api.ExtractPage(ctx, pageNum)
+		if err != nil {
+			logging.Error("Failed to extract PDF page", "pageNum", pageNum, "error", err)
+			return nil, false, fmt.Errorf("failed to extract page %d: %w", pageNum, err)
+		}
+
+		// Read the page data into bytes
+		pageData, err := io.ReadAll(pageReader)
+		if err != nil {
+			logging.Error("Failed to read extracted page data", "pageNum", pageNum, "error", err)
+			return nil, false, fmt.Errorf("failed to read page %d data: %w", pageNum, err)
+		}
+
+		// Convert to ReadSeeker for merging
+		pageReaders = append(pageReaders, bytes.NewReader(pageData))
+	}
+
+	// Create output buffer for the merged PDF
+	var outputBuffer bytes.Buffer
+
+	// Merge all extracted pages into a single PDF
+	logging.Debug("Merging extracted PDF pages", "pageCount", len(pageReaders))
+	err = api.MergeRaw(pageReaders, &outputBuffer, false, model.NewDefaultConfiguration())
+	if err != nil {
+		logging.Error("Failed to merge extracted PDF pages", "error", err)
+		return nil, false, fmt.Errorf("failed to merge extracted pages: %w", err)
+	}
+
+	logging.Debug("PDF pages extracted successfully", "outputSize", outputBuffer.Len(), "wasTruncated", wasTruncated)
+	return outputBuffer.Bytes(), wasTruncated, nil
+}
+
+// ValidatePageSelection validates a page selection string format
+func ValidatePageSelection(pages string) error {
+	if pages == "" {
+		return nil
+	}
+
+	_, err := ParsePageSelection(pages)
+	return err
+}

--- a/mix_agent/internal/llm/tools/read_media.go
+++ b/mix_agent/internal/llm/tools/read_media.go
@@ -28,6 +28,7 @@ type ReadMediaParams struct {
 	WordCount     int    `json:"word_count,omitempty"`
 	AudioMode     string `json:"audio_mode,omitempty"`
 	VideoMode     string `json:"video_mode,omitempty"`
+	PdfPages      string `json:"pdf_pages,omitempty"`
 }
 
 type readMediaTool struct{}
@@ -103,6 +104,10 @@ func (r *readMediaTool) Info() ToolInfo {
 				"type":        "string",
 				"enum":        []string{"description"},
 				"description": "Video analysis mode (required for video type)",
+			},
+			"pdf_pages": map[string]any{
+				"type":        "string",
+				"description": "PDF page selection: single page '5' or ranges '1-3,7,10-12' (PDF only)",
 			},
 		},
 		Required: []string{"media_type", "prompt"},
@@ -201,6 +206,16 @@ func (r *readMediaTool) validateParams(params ReadMediaParams) error {
 	// Validate word count
 	if params.WordCount != 0 && (params.WordCount < MinWordCount || params.WordCount > MaxWordCount) {
 		return fmt.Errorf("word_count must be between %d and %d", MinWordCount, MaxWordCount)
+	}
+
+	// Validate PDF pages parameter
+	if params.PdfPages != "" {
+		if params.MediaType != "pdf" {
+			return fmt.Errorf("pdf_pages parameter can only be used with media_type 'pdf'")
+		}
+		if err := ValidatePageSelection(params.PdfPages); err != nil {
+			return fmt.Errorf("invalid pdf_pages parameter: %w", err)
+		}
 	}
 
 	// Validate paths are absolute (skip for URLs)
@@ -391,6 +406,23 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 			return result
 		}
 
+		// For PDF files, extract pages (with auto-truncation if > 10 pages and no range specified)
+		var wasTruncated bool
+		if params.MediaType == "pdf" {
+			extractedData, truncated, err := ExtractPDFPages(fileData, params.PdfPages)
+			if err != nil {
+				result.Error = fmt.Sprintf("Error extracting PDF pages from URL: %s", err)
+				return result
+			}
+			fileData = extractedData
+			wasTruncated = truncated
+		}
+
+		// Append truncation notice to prompt if PDF was auto-truncated
+		if wasTruncated {
+			analysisPrompt += "\n\nNote: This PDF has been truncated at the tenth page."
+		}
+
 		userMessage = message.Message{
 			Role: message.User,
 			Parts: []message.ContentPart{
@@ -408,6 +440,23 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 		if err != nil {
 			result.Error = fmt.Sprintf("Error reading file: %s", err)
 			return result
+		}
+
+		// For PDF files, extract pages (with auto-truncation if > 10 pages and no range specified)
+		var wasTruncated bool
+		if params.MediaType == "pdf" {
+			extractedData, truncated, err := ExtractPDFPages(fileData, params.PdfPages)
+			if err != nil {
+				result.Error = fmt.Sprintf("Error extracting PDF pages: %s", err)
+				return result
+			}
+			fileData = extractedData
+			wasTruncated = truncated
+		}
+
+		// Append truncation notice to prompt if PDF was auto-truncated
+		if wasTruncated {
+			analysisPrompt += "\n\nNote: This PDF has been truncated at the tenth page."
 		}
 
 		userMessage = message.Message{

--- a/mix_agent/internal/llm/tools/read_media.go
+++ b/mix_agent/internal/llm/tools/read_media.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"mix/internal/config"
@@ -25,10 +26,10 @@ type ReadMediaParams struct {
 	MediaType     string `json:"media_type"`
 	Prompt        string `json:"prompt"`
 	Recursive     bool   `json:"recursive,omitempty"`
-	WordCount     int    `json:"word_count,omitempty"`
 	AudioMode     string `json:"audio_mode,omitempty"`
 	VideoMode     string `json:"video_mode,omitempty"`
 	PdfPages      string `json:"pdf_pages,omitempty"`
+	VideoInterval string `json:"video_interval,omitempty"`
 }
 
 type readMediaTool struct{}
@@ -47,9 +48,6 @@ type ReadMediaResponse struct {
 
 const (
 	ReadMediaToolName = "ReadMedia"
-	DefaultWordCount  = 200
-	MaxWordCount      = 1000
-	MinWordCount      = 50
 )
 
 var supportedImageTypes = []string{".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
@@ -88,13 +86,6 @@ func (r *readMediaTool) Info() ToolInfo {
 				"default":     false,
 				"description": "Process directories recursively",
 			},
-			"word_count": map[string]any{
-				"type":        "integer",
-				"minimum":     MinWordCount,
-				"maximum":     MaxWordCount,
-				"default":     DefaultWordCount,
-				"description": "Target word count for analysis",
-			},
 			"audio_mode": map[string]any{
 				"type":        "string",
 				"enum":        []string{"transcript", "description"},
@@ -108,6 +99,10 @@ func (r *readMediaTool) Info() ToolInfo {
 			"pdf_pages": map[string]any{
 				"type":        "string",
 				"description": "PDF page selection: single page '5' or ranges '1-3,7,10-12' (PDF only)",
+			},
+			"video_interval": map[string]any{
+				"type":        "string",
+				"description": "Video time interval: timestamps '00:20:50-00:26:10' or '20:50-26:10' (video only)",
 			},
 		},
 		Required: []string{"media_type", "prompt"},
@@ -203,11 +198,6 @@ func (r *readMediaTool) validateParams(params ReadMediaParams) error {
 		return fmt.Errorf("video_mode must be 'description'")
 	}
 
-	// Validate word count
-	if params.WordCount != 0 && (params.WordCount < MinWordCount || params.WordCount > MaxWordCount) {
-		return fmt.Errorf("word_count must be between %d and %d", MinWordCount, MaxWordCount)
-	}
-
 	// Validate PDF pages parameter
 	if params.PdfPages != "" {
 		if params.MediaType != "pdf" {
@@ -215,6 +205,17 @@ func (r *readMediaTool) validateParams(params ReadMediaParams) error {
 		}
 		if err := ValidatePageSelection(params.PdfPages); err != nil {
 			return fmt.Errorf("invalid pdf_pages parameter: %w", err)
+		}
+	}
+
+	// Validate video interval parameter
+	if params.VideoInterval != "" {
+		if params.MediaType != "video" {
+			return fmt.Errorf("video_interval parameter can only be used with media_type 'video'")
+		}
+		// Validate the interval format by trying to parse it
+		if _, _, err := parseVideoInterval(params.VideoInterval); err != nil {
+			return fmt.Errorf("invalid video_interval parameter: %w", err)
 		}
 	}
 
@@ -384,6 +385,28 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 	// Prepare analysis prompt
 	analysisPrompt := r.buildAnalysisPrompt(params)
 
+	// Parse video interval if provided
+	var startOffset, endOffset string
+	var videoTruncated bool
+	if params.VideoInterval != "" {
+		var err error
+		startOffset, endOffset, err = parseVideoInterval(params.VideoInterval)
+		if err != nil {
+			result.Error = fmt.Sprintf("Error parsing video interval: %s", err)
+			return result
+		}
+	} else if params.MediaType == "video" {
+		// Auto-truncate videos to first 10 minutes when no interval specified
+		startOffset = "0s"
+		endOffset = "600s" // 10 minutes = 600 seconds
+		videoTruncated = true
+	}
+
+	// Append truncation notice if video was auto-truncated
+	if videoTruncated {
+		analysisPrompt += "\n\nNote: This video has been truncated to the first 10 minutes."
+	}
+
 	// Create message with appropriate content type
 	var userMessage message.Message
 	if isURL(filePath) && isYouTubeURL(filePath) {
@@ -393,8 +416,10 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 			Parts: []message.ContentPart{
 				message.TextContent{Text: analysisPrompt},
 				message.URIContent{
-					URI:      filePath,
-					MIMEType: "video/mp4", // YouTube videos are treated as MP4 by Gemini
+					URI:         filePath,
+					MIMEType:    "video/mp4", // YouTube videos are treated as MP4 by Gemini
+					StartOffset: startOffset,
+					EndOffset:   endOffset,
 				},
 			},
 		}
@@ -428,9 +453,11 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 			Parts: []message.ContentPart{
 				message.TextContent{Text: analysisPrompt},
 				message.BinaryContent{
-					Path:     filePath,
-					MIMEType: mimeType,
-					Data:     fileData,
+					Path:        filePath,
+					MIMEType:    mimeType,
+					Data:        fileData,
+					StartOffset: startOffset,
+					EndOffset:   endOffset,
 				},
 			},
 		}
@@ -464,9 +491,11 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 			Parts: []message.ContentPart{
 				message.TextContent{Text: analysisPrompt},
 				message.BinaryContent{
-					Path:     filePath,
-					MIMEType: mimeType,
-					Data:     fileData,
+					Path:        filePath,
+					MIMEType:    mimeType,
+					Data:        fileData,
+					StartOffset: startOffset,
+					EndOffset:   endOffset,
 				},
 			},
 		}
@@ -591,11 +620,6 @@ func (r *readMediaTool) createGeminiProvider() (interfaces.Provider, error) {
 }
 
 func (r *readMediaTool) buildAnalysisPrompt(params ReadMediaParams) string {
-	wordCount := params.WordCount
-	if wordCount == 0 {
-		wordCount = DefaultWordCount
-	}
-
 	var promptPrefix string
 	switch params.MediaType {
 	case "image":
@@ -612,7 +636,7 @@ func (r *readMediaTool) buildAnalysisPrompt(params ReadMediaParams) string {
 		promptPrefix = "Analyze this PDF document, including both text content and visual elements such as charts, diagrams, and tables. "
 	}
 
-	return fmt.Sprintf("%s%s\n\nPlease provide approximately %d words in your response.", promptPrefix, params.Prompt, wordCount)
+	return fmt.Sprintf("%s%s", promptPrefix, params.Prompt)
 }
 
 func (r *readMediaTool) sendToGemini(ctx context.Context, geminiProvider interfaces.Provider, userMessage message.Message) (string, error) {
@@ -668,4 +692,83 @@ func contains(slice []string, item string) bool {
 		}
 	}
 	return false
+}
+
+// parseTimestamp converts a timestamp string (HH:MM:SS or MM:SS) to seconds
+func parseTimestamp(timestamp string) (int, error) {
+	parts := strings.Split(timestamp, ":")
+
+	var hours, minutes, seconds int
+	var err error
+
+	switch len(parts) {
+	case 2:
+		// MM:SS format
+		minutes, err = strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, fmt.Errorf("invalid minutes: %w", err)
+		}
+		seconds, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, fmt.Errorf("invalid seconds: %w", err)
+		}
+	case 3:
+		// HH:MM:SS format
+		hours, err = strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, fmt.Errorf("invalid hours: %w", err)
+		}
+		minutes, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return 0, fmt.Errorf("invalid minutes: %w", err)
+		}
+		seconds, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return 0, fmt.Errorf("invalid seconds: %w", err)
+		}
+	default:
+		return 0, fmt.Errorf("timestamp must be in HH:MM:SS or MM:SS format")
+	}
+
+	// Validate ranges
+	if minutes < 0 || minutes >= 60 {
+		return 0, fmt.Errorf("minutes must be between 0 and 59")
+	}
+	if seconds < 0 || seconds >= 60 {
+		return 0, fmt.Errorf("seconds must be between 0 and 59")
+	}
+	if hours < 0 {
+		return 0, fmt.Errorf("hours must be non-negative")
+	}
+
+	totalSeconds := hours*3600 + minutes*60 + seconds
+	return totalSeconds, nil
+}
+
+// parseVideoInterval parses a video interval string and returns start/end offsets in Gemini format
+func parseVideoInterval(interval string) (string, string, error) {
+	parts := strings.Split(interval, "-")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("video_interval must be in format 'start-end' (e.g., '00:20:50-00:26:10')")
+	}
+
+	startTimestamp := strings.TrimSpace(parts[0])
+	endTimestamp := strings.TrimSpace(parts[1])
+
+	startSeconds, err := parseTimestamp(startTimestamp)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid start timestamp: %w", err)
+	}
+
+	endSeconds, err := parseTimestamp(endTimestamp)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid end timestamp: %w", err)
+	}
+
+	if startSeconds >= endSeconds {
+		return "", "", fmt.Errorf("start timestamp must be before end timestamp")
+	}
+
+	// Format as Gemini API expects: "1250s", "1570s"
+	return fmt.Sprintf("%ds", startSeconds), fmt.Sprintf("%ds", endSeconds), nil
 }

--- a/mix_agent/internal/llm/tools/read_media.go
+++ b/mix_agent/internal/llm/tools/read_media.go
@@ -21,13 +21,9 @@ import (
 )
 
 type ReadMediaParams struct {
-	FilePath      string `json:"file_path,omitempty"`
-	DirectoryPath string `json:"directory_path,omitempty"`
+	FilePath      string `json:"file_path"`
 	MediaType     string `json:"media_type"`
 	Prompt        string `json:"prompt"`
-	Recursive     bool   `json:"recursive,omitempty"`
-	AudioMode     string `json:"audio_mode,omitempty"`
-	VideoMode     string `json:"video_mode,omitempty"`
 	PdfPages      string `json:"pdf_pages,omitempty"`
 	VideoInterval string `json:"video_interval,omitempty"`
 }
@@ -66,11 +62,7 @@ func (r *readMediaTool) Info() ToolInfo {
 		Parameters: map[string]any{
 			"file_path": map[string]any{
 				"type":        "string",
-				"description": "Path to single file for analysis",
-			},
-			"directory_path": map[string]any{
-				"type":        "string",
-				"description": "Path to directory for batch processing",
+				"description": "Path to file or URL for analysis",
 			},
 			"media_type": map[string]any{
 				"type":        "string",
@@ -81,21 +73,6 @@ func (r *readMediaTool) Info() ToolInfo {
 				"type":        "string",
 				"description": "Analysis prompt for the media content",
 			},
-			"recursive": map[string]any{
-				"type":        "boolean",
-				"default":     false,
-				"description": "Process directories recursively",
-			},
-			"audio_mode": map[string]any{
-				"type":        "string",
-				"enum":        []string{"transcript", "description"},
-				"description": "Audio analysis mode (required for audio type)",
-			},
-			"video_mode": map[string]any{
-				"type":        "string",
-				"enum":        []string{"description"},
-				"description": "Video analysis mode (required for video type)",
-			},
 			"pdf_pages": map[string]any{
 				"type":        "string",
 				"description": "PDF page selection: single page '5' or ranges '1-3,7,10-12' (PDF only)",
@@ -105,7 +82,7 @@ func (r *readMediaTool) Info() ToolInfo {
 				"description": "Video time interval: timestamps '00:20:50-00:26:10' or '20:50-26:10' (video only)",
 			},
 		},
-		Required: []string{"media_type", "prompt"},
+		Required: []string{"file_path", "media_type", "prompt"},
 	}
 }
 
@@ -165,37 +142,14 @@ func (r *readMediaTool) Run(ctx context.Context, call ToolCall) (ToolResponse, e
 }
 
 func (r *readMediaTool) validateParams(params ReadMediaParams) error {
-	// Validate mutually exclusive file/directory paths
-	if params.FilePath != "" && params.DirectoryPath != "" {
-		return fmt.Errorf("cannot specify both file_path and directory_path")
-	}
-
-	if params.FilePath == "" && params.DirectoryPath == "" {
-		return fmt.Errorf("must specify either file_path or directory_path")
+	// Validate file_path is provided
+	if params.FilePath == "" {
+		return fmt.Errorf("file_path is required")
 	}
 
 	// Validate analysis type
 	if params.MediaType != "image" && params.MediaType != "audio" && params.MediaType != "video" && params.MediaType != "pdf" {
 		return fmt.Errorf("media_type must be 'image', 'audio', 'video', or 'pdf'")
-	}
-
-	// Validate type-specific requirements
-	if params.MediaType == "audio" && params.AudioMode == "" {
-		return fmt.Errorf("audio_mode is required when media_type is 'audio'")
-	}
-
-	if params.MediaType == "video" && params.VideoMode == "" {
-		return fmt.Errorf("video_mode is required when media_type is 'video'")
-	}
-
-	// Validate audio mode
-	if params.AudioMode != "" && params.AudioMode != "transcript" && params.AudioMode != "description" {
-		return fmt.Errorf("audio_mode must be 'transcript' or 'description'")
-	}
-
-	// Validate video mode
-	if params.VideoMode != "" && params.VideoMode != "description" {
-		return fmt.Errorf("video_mode must be 'description'")
 	}
 
 	// Validate PDF pages parameter
@@ -213,26 +167,14 @@ func (r *readMediaTool) validateParams(params ReadMediaParams) error {
 		if params.MediaType != "video" {
 			return fmt.Errorf("video_interval parameter can only be used with media_type 'video'")
 		}
-		// Validate the interval format by trying to parse it
 		if _, _, err := parseVideoInterval(params.VideoInterval); err != nil {
 			return fmt.Errorf("invalid video_interval parameter: %w", err)
 		}
 	}
 
-	// Validate paths are absolute (skip for URLs)
-	targetPath := params.FilePath
-	if targetPath == "" {
-		targetPath = params.DirectoryPath
-	}
-
-	// Skip absolute path validation for URLs
-	if params.FilePath != "" && isURL(params.FilePath) {
-		// URLs are supported for all media types
-		return nil
-	}
-
-	if !filepath.IsAbs(targetPath) {
-		return fmt.Errorf("file_path and directory_path must be absolute paths")
+	// Validate path is absolute for local files (skip for URLs)
+	if !isURL(params.FilePath) && !filepath.IsAbs(params.FilePath) {
+		return fmt.Errorf("file_path must be an absolute path")
 	}
 
 	return nil
@@ -258,71 +200,17 @@ func (r *readMediaTool) validateGeminiAPIKey(ctx context.Context) error {
 }
 
 func (r *readMediaTool) getFilesToProcess(params ReadMediaParams) ([]string, error) {
-	var files []string
-
-	if params.FilePath != "" {
-		// Check if it's a URL (YouTube, etc.)
-		if isURL(params.FilePath) {
-			// For URLs, just return the URL as the "file" to process
-			files = append(files, params.FilePath)
-		} else {
-			// Single local file
-			if r.isSupportedFile(params.FilePath, params.MediaType) {
-				files = append(files, params.FilePath)
-			}
-		}
-	} else {
-		// Directory processing
-		var err error
-		files, err = r.findSupportedFiles(params.DirectoryPath, params.MediaType, params.Recursive)
-		if err != nil {
-			return nil, err
-		}
+	// For URLs, return as-is
+	if isURL(params.FilePath) {
+		return []string{params.FilePath}, nil
 	}
 
-	return files, nil
-}
-
-func (r *readMediaTool) findSupportedFiles(dirPath string, mediaType string, recursive bool) ([]string, error) {
-	var files []string
-	var supportedExts []string
-
-	switch mediaType {
-	case "image":
-		supportedExts = supportedImageTypes
-	case "audio":
-		supportedExts = supportedAudioTypes
-	case "video":
-		supportedExts = supportedVideoTypes
-	case "pdf":
-		supportedExts = supportedPDFTypes
+	// For local files, validate support
+	if !r.isSupportedFile(params.FilePath, params.MediaType) {
+		return nil, fmt.Errorf("unsupported file type for media_type '%s': %s", params.MediaType, params.FilePath)
 	}
 
-	walkFn := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if info.IsDir() {
-			if !recursive && path != dirPath {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		ext := strings.ToLower(filepath.Ext(path))
-		for _, supportedExt := range supportedExts {
-			if ext == supportedExt {
-				files = append(files, path)
-				break
-			}
-		}
-
-		return nil
-	}
-
-	err := filepath.Walk(dirPath, walkFn)
-	return files, err
+	return []string{params.FilePath}, nil
 }
 
 func (r *readMediaTool) isSupportedFile(filePath string, mediaType string) bool {
@@ -382,8 +270,8 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 		return result
 	}
 
-	// Prepare analysis prompt
-	analysisPrompt := r.buildAnalysisPrompt(params)
+	// Use the prompt directly
+	analysisPrompt := params.Prompt
 
 	// Parse video interval if provided
 	var startOffset, endOffset string
@@ -432,20 +320,13 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 		}
 
 		// For PDF files, extract pages (with auto-truncation if > 10 pages and no range specified)
-		var wasTruncated bool
 		if params.MediaType == "pdf" {
-			extractedData, truncated, err := ExtractPDFPages(fileData, params.PdfPages)
+			var err error
+			fileData, analysisPrompt, err = processPDFContent(fileData, params.PdfPages, analysisPrompt)
 			if err != nil {
 				result.Error = fmt.Sprintf("Error extracting PDF pages from URL: %s", err)
 				return result
 			}
-			fileData = extractedData
-			wasTruncated = truncated
-		}
-
-		// Append truncation notice to prompt if PDF was auto-truncated
-		if wasTruncated {
-			analysisPrompt += "\n\nNote: This PDF has been truncated at the tenth page."
 		}
 
 		userMessage = message.Message{
@@ -470,20 +351,13 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 		}
 
 		// For PDF files, extract pages (with auto-truncation if > 10 pages and no range specified)
-		var wasTruncated bool
 		if params.MediaType == "pdf" {
-			extractedData, truncated, err := ExtractPDFPages(fileData, params.PdfPages)
+			var err error
+			fileData, analysisPrompt, err = processPDFContent(fileData, params.PdfPages, analysisPrompt)
 			if err != nil {
 				result.Error = fmt.Sprintf("Error extracting PDF pages: %s", err)
 				return result
 			}
-			fileData = extractedData
-			wasTruncated = truncated
-		}
-
-		// Append truncation notice to prompt if PDF was auto-truncated
-		if wasTruncated {
-			analysisPrompt += "\n\nNote: This PDF has been truncated at the tenth page."
 		}
 
 		userMessage = message.Message{
@@ -526,23 +400,7 @@ func (r *readMediaTool) readFileContent(filePath string) ([]byte, string, error)
 	}
 
 	// Detect MIME type
-	mimeType := mime.TypeByExtension(filepath.Ext(filePath))
-	if mimeType == "" {
-		// Fallback MIME type detection
-		ext := strings.ToLower(filepath.Ext(filePath))
-		switch {
-		case contains(supportedImageTypes, ext):
-			mimeType = "image/" + strings.TrimPrefix(ext, ".")
-		case contains(supportedAudioTypes, ext):
-			mimeType = "audio/" + strings.TrimPrefix(ext, ".")
-		case contains(supportedVideoTypes, ext):
-			mimeType = "video/" + strings.TrimPrefix(ext, ".")
-		case contains(supportedPDFTypes, ext):
-			mimeType = "application/pdf"
-		default:
-			mimeType = "application/octet-stream"
-		}
-	}
+	mimeType := detectMIMEType(filePath)
 
 	return data, mimeType, nil
 }
@@ -566,23 +424,10 @@ func (r *readMediaTool) downloadURLToMemory(url string) ([]byte, string, error) 
 		return nil, "", fmt.Errorf("failed to read data: %w", err)
 	}
 
-	// Get MIME type from Content-Type header
+	// Get MIME type from Content-Type header, fallback to extension-based detection
 	mimeType := resp.Header.Get("Content-Type")
 	if mimeType == "" {
-		// Fallback to extension-based detection
-		ext := strings.ToLower(filepath.Ext(url))
-		switch {
-		case contains(supportedImageTypes, ext):
-			mimeType = "image/" + strings.TrimPrefix(ext, ".")
-		case contains(supportedAudioTypes, ext):
-			mimeType = "audio/" + strings.TrimPrefix(ext, ".")
-		case contains(supportedVideoTypes, ext):
-			mimeType = "video/" + strings.TrimPrefix(ext, ".")
-		case contains(supportedPDFTypes, ext):
-			mimeType = "application/pdf"
-		default:
-			mimeType = "application/octet-stream"
-		}
+		mimeType = detectMIMEType(url)
 	}
 
 	return data, mimeType, nil
@@ -617,26 +462,6 @@ func (r *readMediaTool) createGeminiProvider() (interfaces.Provider, error) {
 	}
 
 	return geminiProvider, nil
-}
-
-func (r *readMediaTool) buildAnalysisPrompt(params ReadMediaParams) string {
-	var promptPrefix string
-	switch params.MediaType {
-	case "image":
-		promptPrefix = "Analyze this image and "
-	case "audio":
-		if params.AudioMode == "transcript" {
-			promptPrefix = "Provide an accurate transcription of this audio content. "
-		} else {
-			promptPrefix = "Analyze this audio content and describe "
-		}
-	case "video":
-		promptPrefix = "Analyze this video content, describing both visual and audio elements. "
-	case "pdf":
-		promptPrefix = "Analyze this PDF document, including both text content and visual elements such as charts, diagrams, and tables. "
-	}
-
-	return fmt.Sprintf("%s%s", promptPrefix, params.Prompt)
 }
 
 func (r *readMediaTool) sendToGemini(ctx context.Context, geminiProvider interfaces.Provider, userMessage message.Message) (string, error) {
@@ -677,6 +502,45 @@ func (r *readMediaTool) generateSummary(results []ReadMediaResult) string {
 	}
 
 	return fmt.Sprintf("Analyzed %d file(s) successfully, %d failed.", successCount, errorCount)
+}
+
+// detectMIMEType detects the MIME type for a file path or URL
+func detectMIMEType(path string) string {
+	// Try standard MIME type detection first
+	mimeType := mime.TypeByExtension(filepath.Ext(path))
+	if mimeType != "" {
+		return mimeType
+	}
+
+	// Fallback to extension-based detection
+	ext := strings.ToLower(filepath.Ext(path))
+	switch {
+	case contains(supportedImageTypes, ext):
+		return "image/" + strings.TrimPrefix(ext, ".")
+	case contains(supportedAudioTypes, ext):
+		return "audio/" + strings.TrimPrefix(ext, ".")
+	case contains(supportedVideoTypes, ext):
+		return "video/" + strings.TrimPrefix(ext, ".")
+	case contains(supportedPDFTypes, ext):
+		return "application/pdf"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// processPDFContent handles PDF page extraction and appends truncation notice if needed
+func processPDFContent(fileData []byte, pdfPages string, analysisPrompt string) ([]byte, string, error) {
+	extractedData, truncated, err := ExtractPDFPages(fileData, pdfPages)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Append truncation notice to prompt if PDF was auto-truncated
+	if truncated {
+		analysisPrompt += "\n\nNote: This PDF has been truncated at the tenth page."
+	}
+
+	return extractedData, analysisPrompt, nil
 }
 
 // Helper function to check if a URL is a YouTube URL

--- a/mix_agent/internal/llm/tools/read_media.go
+++ b/mix_agent/internal/llm/tools/read_media.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,6 +54,7 @@ const (
 var supportedImageTypes = []string{".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
 var supportedAudioTypes = []string{".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac"}
 var supportedVideoTypes = []string{".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm", ".mkv"}
+var supportedPDFTypes = []string{".pdf"}
 
 func NewReadMediaTool() BaseTool {
 	return &readMediaTool{}
@@ -73,7 +75,7 @@ func (r *readMediaTool) Info() ToolInfo {
 			},
 			"media_type": map[string]any{
 				"type":        "string",
-				"enum":        []string{"image", "audio", "video"},
+				"enum":        []string{"image", "audio", "video", "pdf"},
 				"description": "Type of media analysis to perform",
 			},
 			"prompt": map[string]any{
@@ -173,8 +175,8 @@ func (r *readMediaTool) validateParams(params ReadMediaParams) error {
 	}
 
 	// Validate analysis type
-	if params.MediaType != "image" && params.MediaType != "audio" && params.MediaType != "video" {
-		return fmt.Errorf("media_type must be 'image', 'audio', or 'video'")
+	if params.MediaType != "image" && params.MediaType != "audio" && params.MediaType != "video" && params.MediaType != "pdf" {
+		return fmt.Errorf("media_type must be 'image', 'audio', 'video', or 'pdf'")
 	}
 
 	// Validate type-specific requirements
@@ -207,12 +209,9 @@ func (r *readMediaTool) validateParams(params ReadMediaParams) error {
 		targetPath = params.DirectoryPath
 	}
 
-	// Skip absolute path validation for URLs (YouTube, etc.)
+	// Skip absolute path validation for URLs
 	if params.FilePath != "" && isURL(params.FilePath) {
-		// URLs are only supported for video media type
-		if params.MediaType != "video" {
-			return fmt.Errorf("URLs are only supported for video media type")
-		}
+		// URLs are supported for all media types
 		return nil
 	}
 
@@ -279,6 +278,8 @@ func (r *readMediaTool) findSupportedFiles(dirPath string, mediaType string, rec
 		supportedExts = supportedAudioTypes
 	case "video":
 		supportedExts = supportedVideoTypes
+	case "pdf":
+		supportedExts = supportedPDFTypes
 	}
 
 	walkFn := func(path string, info os.FileInfo, err error) error {
@@ -330,6 +331,12 @@ func (r *readMediaTool) isSupportedFile(filePath string, mediaType string) bool 
 				return true
 			}
 		}
+	case "pdf":
+		for _, supportedExt := range supportedPDFTypes {
+			if ext == supportedExt {
+				return true
+			}
+		}
 	}
 
 	return false
@@ -364,7 +371,7 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 
 	// Create message with appropriate content type
 	var userMessage message.Message
-	if isURL(filePath) && (strings.Contains(filePath, "youtube.com") || strings.Contains(filePath, "youtu.be")) {
+	if isURL(filePath) && isYouTubeURL(filePath) {
 		// For YouTube URLs, use URIContent with native Gemini support
 		userMessage = message.Message{
 			Role: message.User,
@@ -373,6 +380,25 @@ func (r *readMediaTool) analyzeFile(ctx context.Context, sessionID, messageID, f
 				message.URIContent{
 					URI:      filePath,
 					MIMEType: "video/mp4", // YouTube videos are treated as MP4 by Gemini
+				},
+			},
+		}
+	} else if isURL(filePath) {
+		// For all other URLs, download to memory and use BinaryContent
+		fileData, mimeType, err := r.downloadURLToMemory(filePath)
+		if err != nil {
+			result.Error = fmt.Sprintf("Error downloading from URL: %s", err)
+			return result
+		}
+
+		userMessage = message.Message{
+			Role: message.User,
+			Parts: []message.ContentPart{
+				message.TextContent{Text: analysisPrompt},
+				message.BinaryContent{
+					Path:     filePath,
+					MIMEType: mimeType,
+					Data:     fileData,
 				},
 			},
 		}
@@ -433,6 +459,49 @@ func (r *readMediaTool) readFileContent(filePath string) ([]byte, string, error)
 			mimeType = "audio/" + strings.TrimPrefix(ext, ".")
 		case contains(supportedVideoTypes, ext):
 			mimeType = "video/" + strings.TrimPrefix(ext, ".")
+		case contains(supportedPDFTypes, ext):
+			mimeType = "application/pdf"
+		default:
+			mimeType = "application/octet-stream"
+		}
+	}
+
+	return data, mimeType, nil
+}
+
+func (r *readMediaTool) downloadURLToMemory(url string) ([]byte, string, error) {
+	// Download the media file from URL
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to download from URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for HTTP errors
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("failed to download: HTTP %d", resp.StatusCode)
+	}
+
+	// Read the response body
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read data: %w", err)
+	}
+
+	// Get MIME type from Content-Type header
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		// Fallback to extension-based detection
+		ext := strings.ToLower(filepath.Ext(url))
+		switch {
+		case contains(supportedImageTypes, ext):
+			mimeType = "image/" + strings.TrimPrefix(ext, ".")
+		case contains(supportedAudioTypes, ext):
+			mimeType = "audio/" + strings.TrimPrefix(ext, ".")
+		case contains(supportedVideoTypes, ext):
+			mimeType = "video/" + strings.TrimPrefix(ext, ".")
+		case contains(supportedPDFTypes, ext):
+			mimeType = "application/pdf"
 		default:
 			mimeType = "application/octet-stream"
 		}
@@ -490,6 +559,8 @@ func (r *readMediaTool) buildAnalysisPrompt(params ReadMediaParams) string {
 		}
 	case "video":
 		promptPrefix = "Analyze this video content, describing both visual and audio elements. "
+	case "pdf":
+		promptPrefix = "Analyze this PDF document, including both text content and visual elements such as charts, diagrams, and tables. "
 	}
 
 	return fmt.Sprintf("%s%s\n\nPlease provide approximately %d words in your response.", promptPrefix, params.Prompt, wordCount)
@@ -533,6 +604,11 @@ func (r *readMediaTool) generateSummary(results []ReadMediaResult) string {
 	}
 
 	return fmt.Sprintf("Analyzed %d file(s) successfully, %d failed.", successCount, errorCount)
+}
+
+// Helper function to check if a URL is a YouTube URL
+func isYouTubeURL(url string) bool {
+	return strings.Contains(url, "youtube.com") || strings.Contains(url, "youtu.be")
 }
 
 // Helper function to check if a slice contains a string

--- a/mix_agent/internal/message/content.go
+++ b/mix_agent/internal/message/content.go
@@ -92,9 +92,11 @@ func (iuc ImageURLContent) String() string {
 func (ImageURLContent) isPart() {}
 
 type BinaryContent struct {
-	Path     string
-	MIMEType string
-	Data     []byte
+	Path        string
+	MIMEType    string
+	Data        []byte
+	StartOffset string // Video metadata: start time offset (e.g., "1250s")
+	EndOffset   string // Video metadata: end time offset (e.g., "1570s")
 }
 
 func (bc BinaryContent) String(provider models.ModelProvider) string {
@@ -108,8 +110,10 @@ func (bc BinaryContent) String(provider models.ModelProvider) string {
 func (BinaryContent) isPart() {}
 
 type URIContent struct {
-	URI      string `json:"uri"`
-	MIMEType string `json:"mime_type"`
+	URI         string `json:"uri"`
+	MIMEType    string `json:"mime_type"`
+	StartOffset string `json:"start_offset,omitempty"` // Video metadata: start time offset (e.g., "1250s")
+	EndOffset   string `json:"end_offset,omitempty"`   // Video metadata: end time offset (e.g., "1570s")
 }
 
 func (uc URIContent) String() string {

--- a/mix_playground/src/components/CsvViewer.tsx
+++ b/mix_playground/src/components/CsvViewer.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import {
   Table,
   TableBody,
@@ -8,108 +7,15 @@ import {
   TableRow,
   TableCaption,
 } from '@/components/ui/table';
+import { useCsvData } from '@/hooks/useCsv';
 
 interface CsvViewerProps {
   url: string;
   title: string;
 }
 
-interface ParsedCsv {
-  headers: string[];
-  rows: string[][];
-  totalRows: number;
-  totalColumns: number;
-}
-
-const parseCSV = (csvText: string): ParsedCsv => {
-  const lines = csvText.trim().split('\n');
-  const headers: string[] = [];
-  const rows: string[][] = [];
-
-  if (lines.length === 0) {
-    return { headers, rows, totalRows: 0, totalColumns: 0 };
-  }
-
-  // Simple CSV parser - handles basic cases
-  const parseLine = (line: string): string[] => {
-    const result: string[] = [];
-    let current = '';
-    let inQuotes = false;
-
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i];
-      const nextChar = line[i + 1];
-
-      if (char === '"') {
-        if (inQuotes && nextChar === '"') {
-          // Escaped quote
-          current += '"';
-          i++; // Skip next quote
-        } else {
-          // Toggle quote state
-          inQuotes = !inQuotes;
-        }
-      } else if (char === ',' && !inQuotes) {
-        // End of field
-        result.push(current.trim());
-        current = '';
-      } else {
-        current += char;
-      }
-    }
-
-    // Add the last field
-    result.push(current.trim());
-    return result;
-  };
-
-  // Parse headers
-  headers.push(...parseLine(lines[0]));
-
-  // Parse data rows
-  for (let i = 1; i < lines.length; i++) {
-    const row = parseLine(lines[i]);
-    if (row.length > 0 && row.some(cell => cell.length > 0)) {
-      rows.push(row);
-    }
-  }
-
-  return {
-    headers,
-    rows,
-    totalRows: rows.length,
-    totalColumns: headers.length,
-  };
-};
-
 export const CsvViewer = ({ url }: CsvViewerProps) => {
-  const [csvData, setCsvData] = useState<ParsedCsv | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const fetchAndParseCsv = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const csvText = await response.text();
-        const parsed = parseCSV(csvText);
-        setCsvData(parsed);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load CSV file');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchAndParseCsv();
-  }, [url]);
+  const { data: csvData, isLoading: loading, error } = useCsvData(url);
 
   if (loading) {
     return (
@@ -122,7 +28,7 @@ export const CsvViewer = ({ url }: CsvViewerProps) => {
   if (error) {
     return (
       <div className="flex h-48 items-center justify-center rounded-md bg-stone-700/30">
-        <div className="text-stone-400">Failed to load CSV: {error}</div>
+        <div className="text-stone-400">Failed to load CSV: {error instanceof Error ? error.message : 'Unknown error'}</div>
       </div>
     );
   }

--- a/mix_playground/src/components/file-upload-button.tsx
+++ b/mix_playground/src/components/file-upload-button.tsx
@@ -47,7 +47,7 @@ export function FileUploadButton({
           },
           {
             name: 'Documents',
-            extensions: ['pdf', 'doc', 'docx', 'txt', 'md', 'rtf']
+            extensions: ['pdf', 'doc', 'docx', 'txt', 'md', 'rtf', 'csv', 'xls', 'xlsx']
           }
         ]
       });
@@ -167,6 +167,9 @@ function getMimeType(fileName: string): string {
     txt: 'text/plain',
     md: 'text/markdown',
     rtf: 'application/rtf',
+    csv: 'text/csv',
+    xls: 'application/vnd.ms-excel',
+    xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     
     // Code
     js: 'text/javascript',

--- a/mix_playground/src/hooks/useCsv.ts
+++ b/mix_playground/src/hooks/useCsv.ts
@@ -1,0 +1,90 @@
+import { useQuery } from '@tanstack/react-query';
+import { CACHE_KEYS } from '@/lib/cache-keys';
+
+interface ParsedCsv {
+  headers: string[];
+  rows: string[][];
+  totalRows: number;
+  totalColumns: number;
+}
+
+const parseCSV = (csvText: string): ParsedCsv => {
+  const lines = csvText.trim().split('\n');
+  const headers: string[] = [];
+  const rows: string[][] = [];
+
+  if (lines.length === 0) {
+    return { headers, rows, totalRows: 0, totalColumns: 0 };
+  }
+
+  // Simple CSV parser - handles basic cases
+  const parseLine = (line: string): string[] => {
+    const result: string[] = [];
+    let current = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i++) {
+      const char = line[i];
+      const nextChar = line[i + 1];
+
+      if (char === '"') {
+        if (inQuotes && nextChar === '"') {
+          // Escaped quote
+          current += '"';
+          i++; // Skip next quote
+        } else {
+          // Toggle quote state
+          inQuotes = !inQuotes;
+        }
+      } else if (char === ',' && !inQuotes) {
+        // End of field
+        result.push(current.trim());
+        current = '';
+      } else {
+        current += char;
+      }
+    }
+
+    // Add the last field
+    result.push(current.trim());
+    return result;
+  };
+
+  // Parse headers
+  headers.push(...parseLine(lines[0]));
+
+  // Parse data rows
+  for (let i = 1; i < lines.length; i++) {
+    const row = parseLine(lines[i]);
+    if (row.length > 0 && row.some(cell => cell.length > 0)) {
+      rows.push(row);
+    }
+  }
+
+  return {
+    headers,
+    rows,
+    totalRows: rows.length,
+    totalColumns: headers.length,
+  };
+};
+
+async function fetchCsvData(url: string): Promise<ParsedCsv> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const csvText = await response.text();
+  return parseCSV(csvText);
+}
+
+export function useCsvData(url: string) {
+  return useQuery({
+    queryKey: CACHE_KEYS.csvData(url),
+    queryFn: () => fetchCsvData(url),
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    enabled: !!url,
+  });
+}

--- a/mix_playground/src/lib/cache-keys.ts
+++ b/mix_playground/src/lib/cache-keys.ts
@@ -9,4 +9,5 @@ export const CACHE_KEYS = {
   toolsStatus: ['tools', 'status'] as const,
   animationSchema: (animationName: string) => ['gsap', 'animation', 'schema', animationName] as const,
   animationList: ['gsap', 'animations'] as const,
+  csvData: (url: string) => ['csv', 'data', url] as const,
 } as const;


### PR DESCRIPTION
## Summary

- Add comprehensive URL support for all media types (images, audio, PDFs, videos) in addition to existing YouTube support
- Implement elegant two-path architecture preserving YouTube optimization while enabling universal URL support  
- Remove artificial media type restrictions that previously limited URLs to only videos
- Add PDF support to Gemini provider's supported inline formats

## Key Changes

### 🔄 Refactored URL Architecture
- **YouTube URLs**: Continue using native `URIContent` for optimal performance
- **All other URLs**: Universal `downloadURLToMemory()` function with `BinaryContent`
- **Simplified logic**: Reduced from 3 specialized code paths to 2 clean paths

### 🌐 Universal URL Support  
- **Before**: Only YouTube videos + artificial restrictions
- **After**: All media types work seamlessly
  - ✅ Image URLs: `https://example.com/photo.jpg`
  - ✅ Audio URLs: `https://example.com/podcast.mp3` 
  - ✅ PDF URLs: `https://example.com/document.pdf`
  - ✅ Video URLs: `https://example.com/video.mp4`
  - ✅ YouTube URLs: `https://youtube.com/watch?v=abc` (unchanged)

### 🛠️ Technical Improvements
- Added `application/pdf` to Gemini provider's supported inline formats
- Comprehensive MIME type detection for all downloaded content
- Generic `downloadURLToMemory()` replaces media-specific functions
- Updated validation to support URLs for all media types
- Enhanced CSV viewer with TanStack Query for better caching

## Test plan

- [x] YouTube URLs continue working (existing functionality preserved)
- [x] Image URLs work for analysis 
- [x] PDF URLs work without "Unsupported inline format" warnings
- [x] Audio/video URLs support added  
- [x] Local HTTP URLs work (localhost, internal networks)
- [x] Compilation successful with no errors

🤖 Generated with [Claude Code](https://claude.ai/code)