### PR TITLE
docs: fix broken quickstart links in index page

### DIFF
--- a/docs/content/docs/mix/index.mdx
+++ b/docs/content/docs/mix/index.mdx
@@ -6,7 +6,7 @@ description: What's Mix ?
 > Mix is the agentic backbone for your AI apps. It's similar to the Claude Code SDK but is open source and done right.
 
 
-[Complete quickstart guide (5 minutes) →](/docs/mix-agent/quickstart)
+[Complete quickstart guide (5 minutes) →](/docs/mix/quickstart)
 
 ## What Mix Agent Provides
 
@@ -56,4 +56,4 @@ You want to build agents with power of claude code but you want any one or all o
 Proceed to the next steps to learn how to build powerful agentic applications with Mix:
 
 - [Examples](/docs/examples) 
-- [Quickstart](/docs/mix-agent/quickstart) 
+- [Quickstart](/docs/mix/quickstart) 


### PR DESCRIPTION
Fixed incorrect documentation links:
- Changed `/docs/mix-agent/quickstart` to `/docs/mix/quickstart`
- Updated both main quickstart link and footer link

This ensures users can navigate properly from the index page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)