### PR TITLE
fix: refresh title and summarize providers after OAuth login

### DIFF
--- a/mix_agent/internal/http/rest_auth.go
+++ b/mix_agent/internal/http/rest_auth.go
@@ -447,6 +447,13 @@ func (h *AuthHandler) HandleOAuthCallback(w http.ResponseWriter, r *http.Request
 	// Clean up the OAuth flow
 	llmprovider.CleanupOAuthFlow(req.State)
 
+	// Refresh all agent providers to pick up the new OAuth credentials
+	// This is critical for title generation and summarization to work
+	if h.app.CoderAgent != nil {
+		h.app.CoderAgent.ClearAllSessionProviders()
+		logging.Info("Refreshed agent providers after OAuth login")
+	}
+
 	// Track successful authentication
 	if h.app.Analytics != nil {
 		ctx := r.Context()

--- a/mix_agent/internal/llm/agent/agent.go
+++ b/mix_agent/internal/llm/agent/agent.go
@@ -1307,4 +1307,23 @@ func (a *agent) ClearAllSessionProviders() {
 	} else {
 		logging.Error("Failed to update main agent provider", "error", err)
 	}
+
+	// Refresh title and summarize providers (they always use AgentMain config)
+	if a.titleProvider != nil {
+		newTitleProvider, err := createAgentProvider(config.AgentMain)
+		if err == nil {
+			a.titleProvider = newTitleProvider
+		} else {
+			logging.Error("Failed to refresh title provider", "error", err)
+		}
+	}
+
+	if a.summarizeProvider != nil {
+		newSummarizeProvider, err := createAgentProvider(config.AgentMain)
+		if err == nil {
+			a.summarizeProvider = newSummarizeProvider
+		} else {
+			logging.Error("Failed to refresh summarize provider", "error", err)
+		}
+	}
 }


### PR DESCRIPTION
Fixed authentication error in title generation after OAuth login. The titleProvider and summarizeProvider were created at startup with placeholder auth, but never refreshed after successful OAuth login.

Changes:
- Extended ClearAllSessionProviders() to refresh title and summarize providers
- Call ClearAllSessionProviders() in OAuth callback to pick up new credentials
- This ensures title generation works immediately after OAuth authentication

Fixes the "authentication_error: Authentication required" error that occurred when generating conversation titles after OAuth login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)