### PR TITLE
docs: fix footer documentation link

### DIFF
--- a/docs/components/footer.tsx
+++ b/docs/components/footer.tsx
@@ -38,7 +38,7 @@ function Footer({
             <h3 className="text-lg font-medium">Resources</h3>
             <ul className="space-y-2 text-sm">
               <li>
-                <Link href="/docs" className="text-muted-foreground hover:text-primary">Documentation</Link>
+                <Link href="/docs/mix" className="text-muted-foreground hover:text-primary">Documentation</Link>
               </li>
               <li>
                 <Link href="/blog" className="text-muted-foreground hover:text-primary">Blog</Link>


### PR DESCRIPTION
Changed documentation link from /docs to /docs/mix to point to the correct starting page for Mix documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)