### PR TITLE
fix: improve homepage demo card layout and alignment

### DIFF
--- a/docs/components/demo-cards.tsx
+++ b/docs/components/demo-cards.tsx
@@ -29,9 +29,9 @@ export function DemoCards({ demos }: DemoCardsProps) {
     <div className="container px-4 pb-8">
       {/* Selected demo showcase */}
       <div className="max-w-7xl mx-auto">
-        <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 items-start">
-          {/* Code section - takes 2 columns */}
-          <div className="lg:col-span-2 space-y-4">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
+          {/* Code section */}
+          <div className="space-y-4">
             <div className="rounded-2xl border-2 border-fd-border/50 bg-gradient-to-br from-fd-card to-fd-muted/20 overflow-hidden shadow-xl">
               <div className="bg-gradient-to-r from-fd-muted/80 to-fd-muted/60 backdrop-blur-sm px-5 py-3 border-b border-fd-border/50 flex items-center justify-between">
                 <div className="flex items-center gap-3">
@@ -63,8 +63,8 @@ export function DemoCards({ demos }: DemoCardsProps) {
             </div>
           </div>
 
-          {/* Video section - takes 3 columns */}
-          <div className="lg:col-span-3 lg:sticky lg:top-8">
+          {/* Video section */}
+          <div className="flex flex-col justify-center">
             <div className="rounded-2xl overflow-hidden border-2 border-fd-primary/20 shadow-2xl bg-gradient-to-br from-fd-card to-fd-muted/30 p-1">
               <div className="rounded-xl overflow-hidden bg-black aspect-video">
                 <video


### PR DESCRIPTION
- Changed grid from 5-column (2:3 ratio) to 2-column (1:1 ratio) for balanced layout
- Fixed video alignment by changing items-start to items-center on grid
- Removed sticky positioning from video section to enable smooth scrolling
- Added flex justify-center to video container for vertical centering

This resolves the misalignment and sticky scroll issues on the homepage demo showcase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)