### PR TITLE
fix(docs): use HTML img tag for launch gif to bypass Next.js optimiza…

### DIFF
--- a/docs/content/docs/mix/guides/using-devtools.mdx
+++ b/docs/content/docs/mix/guides/using-devtools.mdx
@@ -24,7 +24,7 @@ cd mix
 make dev
 ```
 
-![Launch Mix DevTools](/gifs/launch_mix.gif)
+<img src="/gifs/launch_mix.gif" alt="Launch Mix DevTools" className="w-full rounded-lg" />
 
 </Step>
 <Step>


### PR DESCRIPTION
…tion

Changed from markdown image syntax to HTML img tag for the launch_mix.gif. Next.js image optimization doesn't handle large animated GIFs well, causing 400 errors on production. Direct img tag serves the GIF from public folder without optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)